### PR TITLE
Improve dynamic SQL generation

### DIFF
--- a/PredictionOpenAI/README.md
+++ b/PredictionOpenAI/README.md
@@ -6,6 +6,7 @@ An LLM-integrated time series forecasting tool that uses OpenAI to interpret bus
 
 - Natural language interface for business forecasting
 - Smart SQL query generation using LLM
+  - LLM can specify which columns to retrieve
 - Multi-model ensemble: SARIMA, LSTM, XGBoost, ARIMA
 - Dockerized for deployment
 - Logs and prompt history support

--- a/PredictionOpenAI/app/prompts/prompt_template.txt
+++ b/PredictionOpenAI/app/prompts/prompt_template.txt
@@ -6,4 +6,5 @@ Respond with a Python dictionary with keys:
 - "table": name of the SQL table to fetch from
 - "date_column": the column with datetime
 - "target_column": the column to predict
+- "columns": list of additional columns required (optional)
 - "filters": any SQL WHERE filters (optional)

--- a/PredictionOpenAI/app/utils/DataFetcher.py
+++ b/PredictionOpenAI/app/utils/DataFetcher.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from sqlalchemy import text, inspect
 from utils.DatabaseConnection import get_db_engine
 
 def fetch_data(query_info, extra_columns=None):
@@ -8,14 +9,20 @@ def fetch_data(query_info, extra_columns=None):
     table = query_info['table']
     filters = query_info.get('filters', '')
 
-    columns = [date_col, target_col, 'Customercode']
+    columns = query_info.get('columns', [date_col, target_col])
     if extra_columns:
         columns.extend(extra_columns)
 
-    col_str = ', '.join(columns)
-    sql = f"SELECT {col_str} FROM {table}"
-    if filters:
-        sql += f" WHERE {filters}"
+    inspector = inspect(engine)
+    table_columns = [c['name'] for c in inspector.get_columns(table)]
+    for col in columns:
+        if col not in table_columns:
+            raise ValueError(f"Column '{col}' does not exist in table '{table}'")
 
-    df = pd.read_sql(sql, engine, parse_dates=[date_col])
+    col_str = ', '.join(columns)
+    sql = text(f"SELECT {col_str} FROM {table}")
+    if filters:
+        sql = text(f"{sql.text} WHERE {filters}")
+
+    df = pd.read_sql_query(sql, engine, parse_dates=[date_col])
     return df.sort_values(by=date_col)

--- a/PredictionOpenAI/app/utils/QueryProcessor.py
+++ b/PredictionOpenAI/app/utils/QueryProcessor.py
@@ -28,6 +28,4 @@ def parse_query(query):
     try:
         return json.loads(content)
     except Exception as e:
-        print("❌ Failed to parse JSON:", e)
-        print("🔍 Raw response:\n", content)
-        return {}
+        raise ValueError(f"Failed to parse JSON response: {e}\nRaw response: {content}")

--- a/PredictionOpenAI/requirements.txt
+++ b/PredictionOpenAI/requirements.txt
@@ -5,6 +5,7 @@ psycopg2-binary
 pymysql
 pyodbc
 pandas
+joblib
 numpy
 matplotlib
 scikit-learn
@@ -14,3 +15,5 @@ pmdarima
 torch
 transformers
 flask
+tensorflow
+pytest

--- a/PredictionOpenAI/tests/test_datafetcher.py
+++ b/PredictionOpenAI/tests/test_datafetcher.py
@@ -1,0 +1,47 @@
+import os
+import pandas as pd
+import pytest
+from sqlalchemy import text
+
+from utils.DatabaseConnection import get_db_engine
+from utils.DataFetcher import fetch_data
+
+DB_FILE = 'test.db'
+
+def setup_module(module):
+    os.environ['DB_TYPE'] = 'sqlite'
+    os.environ['DB_PATH'] = DB_FILE
+    if os.path.exists(DB_FILE):
+        os.remove(DB_FILE)
+    engine = get_db_engine()
+    with engine.begin() as conn:
+        conn.execute(text('CREATE TABLE sales (date TEXT, sales INTEGER, category TEXT)'))
+        conn.execute(text("INSERT INTO sales VALUES ('2023-01-01', 100, 'A')"))
+
+
+def teardown_module(module):
+    if os.path.exists(DB_FILE):
+        os.remove(DB_FILE)
+
+
+def test_fetch_data_valid_columns():
+    query_info = {
+        'table': 'sales',
+        'date_column': 'date',
+        'target_column': 'sales',
+        'columns': ['date', 'sales', 'category']
+    }
+    df = fetch_data(query_info)
+    assert list(df.columns) == ['date', 'sales', 'category']
+    assert not df.empty
+
+
+def test_fetch_data_invalid_column():
+    query_info = {
+        'table': 'sales',
+        'date_column': 'date',
+        'target_column': 'sales',
+        'columns': ['date', 'sales', 'missing']
+    }
+    with pytest.raises(ValueError):
+        fetch_data(query_info)

--- a/PredictionOpenAI/tests/test_queryprocessor.py
+++ b/PredictionOpenAI/tests/test_queryprocessor.py
@@ -1,0 +1,18 @@
+import json
+import types
+import pytest
+
+from utils import QueryProcessor
+
+class DummyResponse:
+    def __init__(self, content):
+        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+
+def dummy_create(*args, **kwargs):
+    return DummyResponse('{invalid}')
+
+
+def test_parse_query_invalid_json(monkeypatch):
+    monkeypatch.setattr(QueryProcessor.client.chat.completions, 'create', dummy_create)
+    with pytest.raises(ValueError):
+        QueryProcessor.parse_query('test query')


### PR DESCRIPTION
## Summary
- add column list to the LLM prompt
- validate columns returned by the LLM
- use SQLAlchemy `text` for query building
- raise structured errors if the response from OpenAI is invalid
- add basic unit tests for data fetching and query parsing
- document column support in README

## Testing
- `pytest PredictionOpenAI/tests` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6843ef2db9088322b3cbfc2130737060