### PR TITLE
Add schema metadata and SQL validation

### DIFF
--- a/PredictionOpenAI/app/prompts/prompt_template.txt
+++ b/PredictionOpenAI/app/prompts/prompt_template.txt
@@ -4,6 +4,7 @@ structured metadata for building data pipelines.  The database type is
 include a full SQL query if you can.
 
 Database type: {{db_type}}
+Available schemas and tables: {{schema_metadata}}
 Query: {{query}}
 
 Return a dictionary with these keys:

--- a/PredictionOpenAI/app/utils/QueryProcessor.py
+++ b/PredictionOpenAI/app/utils/QueryProcessor.py
@@ -14,10 +14,20 @@ def parse_query(query):
     with open(os.path.abspath(prompt_path), 'r') as f:
         prompt_template = f.read()
 
+    schema_file = os.path.join(base_dir, '..', 'data', 'schema_info.json')
+    schema_info = ''
+    if os.path.exists(schema_file):
+        with open(schema_file, 'r') as f:
+            try:
+                schema_info = json.dumps(json.load(f))
+            except Exception:
+                schema_info = ''
+
     db_type = os.getenv("DB_TYPE", "")
     full_prompt = (prompt_template
                    .replace("{{query}}", query)
-                   .replace("{{db_type}}", db_type))
+                   .replace("{{db_type}}", db_type)
+                   .replace("{{schema_metadata}}", schema_info))
 
 
     try:

--- a/PredictionOpenAI/requirements.txt
+++ b/PredictionOpenAI/requirements.txt
@@ -18,3 +18,4 @@ flask>=2.2
 tensorflow>=2.14
 pytest>=8.0
 pymongo>=4.5
+sqlparse>=0.4


### PR DESCRIPTION
## Summary
- show table columns and datatypes when connecting to DB
- save schema metadata for prompting
- include schema info in LLM prompt
- validate SQL syntax before execution
- add sqlparse dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684670949c308322ab40355854d01d7e